### PR TITLE
PSNC.json file is corrected with the right image name

### DIFF
--- a/Resources/data/repos_data/PSNC.json
+++ b/Resources/data/repos_data/PSNC.json
@@ -1,5 +1,5 @@
 {
     "title": "PSNC multimedia repository",
     "description": "Poznan Supercomputing and Networking Center (PSNC) is affiliated to Institute of Bioorganic Chemistry Polish Academy of Sciences and was established in 1993 by the State Committee for Scientific Research.",
-    "thumbnail_url": "TNC.jpg"
+    "thumbnail_url": "PSNC.png"
 }


### PR DESCRIPTION
#54 PSNC repository image is fixed
