### PR TITLE
TTK-15369 Errors importing contents from K12

### DIFF
--- a/Services/FeedProcesserService.php
+++ b/Services/FeedProcesserService.php
@@ -50,7 +50,14 @@ class FeedProcesserService
         $processedObject['record_date'] = $date;
         $processedObject['copyright'] = $this->retrieveCopyright($geantFeedObject, $lang);
         $processedObject['license'] = $this->retrieveCopyright($geantFeedObject, $lang);
-        $processedObject['track_url'] = isset($geantFeedObject['expressions']['manifestations']['items']['url']) ? $geantFeedObject['expressions']['manifestations']['items']['url'] : '';
+
+        if (isset($geantFeedObject['expressions']['manifestations']['items']['url'])) {
+            $processedObject['track_url'] = $geantFeedObject['expressions']['manifestations']['items']['url'];
+        } elseif (isset($geantFeedObject['expressions']['manifestations']['items'][0]['url'])) {
+            $processedObject['track_url'] = $geantFeedObject['expressions']['manifestations']['items'][0]['url'];
+        } else {
+            $processedObject['track_url'] = '';
+        }
 
         if ($processedObject['track_url'] == '') {
             throw new FeedSyncException(sprintf('The object with identifier: %s does not have an url (expressions/manifestations/items/url).', $processedObject['identifier']));
@@ -94,7 +101,8 @@ class FeedProcesserService
         $languageNames = Intl::getLanguageBundle()->getLanguageNames();
 
         if (!array_key_exists($lang, $languageNames)) {
-            throw new FeedSyncException(sprintf('The feed with ID: %s has a language format that is not recognized: %s', $geantFeedObject['identifier'], $geantFeedObject['expressions']['language']));
+            //throw new FeedSyncException(sprintf('The feed with ID: %s has a language format that is not recognized: %s', $geantFeedObject['identifier'], $geantFeedObject['expressions']['language']));
+            $lang = 'Unknown';
         }
 
         return $lang;


### PR DESCRIPTION
1.- Items with many urls.

PuMuKIT not implements import an object with several urls.

For example, see expressions/manifestations/items in
https://oer.up2university.eu/search/v1/akif?set=UAL&q=Bonnie_Marranca_Part_1

```
"expressions": {
    "language": "en",
    "manifestations": {
        "items": [
            {
                "broken": false,
                "url":
    "http://ualresearchonline.arts.ac.uk/5119/1/rome.jpg"
            },
            {
                "broken": false,
                "url": "Stickland, Peter
    &lt;http://ualresearchonline.arts.ac.uk/view/creators/Stickland=3APeter=3A=3A.html&gt;
    and Toren, Amikam ..."
            },
            {
                "broken": false,
                "url": "http://ualresearchonline.arts.ac.uk/5119/"
            },
            {
                "broken": false,
                "url": "http://www.77books.co.uk/"
            }
        ],
    "format": "image"
}
```

2.- Unrecognized language:

K12 - DLESE catalogue has objects with a language format that is not
recognized: en-US

The language format must be ISO 639-1 Code or ISO 639-2 Code.

Example:See expressions/language in
https://oer.up2university.eu/search/v1/akif?set=DLESE&format=video.

When the next update, objects with unrecognized language will be convert
to unknown language and not filtered.